### PR TITLE
Fixed Direct Messaging Bug

### DIFF
--- a/src/main/java/com/google/codeu/servlets/MessageServlet.java
+++ b/src/main/java/com/google/codeu/servlets/MessageServlet.java
@@ -121,7 +121,7 @@ public class MessageServlet extends HttpServlet {
     setMessageImageUrl(request, message);
     datastore.storeMessage(message);
 
-    response.sendRedirect("/user-page.html?user=" + user);
+    response.sendRedirect("/user-page.html?user=" + recipient);
   }
 
   /* Function that handles all blobstore requests for adding an image


### PR DESCRIPTION
When a user direct-messages someone it takes them to that page instead of keeping the user on it's own page. This way the user can see the message was sent.