### PR TITLE
Added missing code to user-page html and fixed Message error

### DIFF
--- a/src/main/java/com/google/codeu/data/Message.java
+++ b/src/main/java/com/google/codeu/data/Message.java
@@ -19,7 +19,7 @@ package com.google.codeu.data;
 import java.util.UUID;
 
 /** A single message posted by a user. */
-public class Message extends Event {
+public class Message {
 
   private UUID id;
   private String user;

--- a/src/main/webapp/user-page.html
+++ b/src/main/webapp/user-page.html
@@ -25,7 +25,17 @@ This is the path of html wich Navigation-loader.js has.(Dependency)
     <link rel="stylesheet" href="/css/event.css">
     <link rel="stylesheet" href="https://fonts.googleapis.com/css?family=Nunito">
     <script src="/js/user-page-loader.js"></script>
-  
+</head>
+<body onload="buildUI();">
+    <nav id="navigation">
+        <br>
+        <br>
+        <br>
+        <ul>
+            <a href="/ ">
+                <li>HOME</li>
+            </a>
+        </ul>
     </nav>
     <div class="content">
 


### PR DESCRIPTION
There was an error where the profile page would not load. This was due to some html in user-page.html that had gone missing through an earlier merge to master and an error in forgetting to delete some stuff on  Message.java. The Message class was accidentally extending to the Event class, because I was trying to implement an inheritance functionality. I forgot to delete this "extends Event" and it messed up how the Messages were saved and loaded.